### PR TITLE
Adds an ID to the applet tag

### DIFF
--- a/FuzzyTruck.html
+++ b/FuzzyTruck.html
@@ -473,7 +473,7 @@ required jar file (<span class=SpellE>swingall.jar</span>). <br>
 
 <p style='margin-top:.1pt;margin-right:0cm;margin-bottom:.1pt;margin-left:0cm'>
 
-<applet code="examples/fuzzytruckswing/FuzzyTruckJApplet.class" width=800
+<applet id="applet" code="examples/fuzzytruckswing/FuzzyTruckJApplet.class" width=800
  height=472 name="Fuzzy Truck Applet" archive=FuzzyTruckJAppletNew.jar
  alt="Your browser supports the Applet tag but cannot start the application: perhaps Java applet support is disabled">
  Sorry, No Java appears to be available for the browser!!! 


### PR DESCRIPTION
The ID will enable jumping directly to the truck applet, using a link http://rorchard.github.io/FuzzyJ/FuzzyTruck.html#applet

This way it's easier to point to the Fuzzy Truck application when using it as an example of Fuzzy Logic applications.